### PR TITLE
Fixed donate button being covered

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,7 +17,7 @@ import { Image } from "astro:assets";
                </a>
             </div>
          </div>
-         <div class='inline-block h-[220vw] lg:h-[160vw] w-[160vw] bg-white rounded-full m-auto absolute left-[calc(50vw-80vw)]' style='top: calc(100vh - 40vh); box-shadow: -1rem -1rem 4rem #fff, inset 0 0 8rem #333'>
+         <div class='inline-block h-[220vw] lg:h-[160vw] w-[160vw] bg-white rounded-full m-auto absolute left-[calc(50vw-80vw)]' style='top: calc(100vh - 20vh); box-shadow: -1rem -1rem 4rem #fff, inset 0 0 8rem #333'>
             <div class='container mt-[40vh] mx-auto text-black w-[100vw] m-16'>
                <h2 class="text-4xl font-['Roboto'] font-bold text-center mb-4">What is Zenith 2025?</h2>
                <p class='text-center max-w-[700px] mx-auto text-xl leading-7'>


### PR DESCRIPTION
This is a half-fix. Now the donate button will never be covered on all standard phone viewports down to iPhone 7 sized screens. But this fix can be improved to be responsive, one would need to use viewport height breakpoints in the style of the "star". No idea how one would do that with tailwind-css. But it looks good on desktop and fine on screens with a rather high viewport like the iPhone 14 Pro so one can probably get away with this...